### PR TITLE
test: add simulated roaming for get tile tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ docker build . -t osml-tile-server:latest
 To build the container in a build/test mode and work inside it.
 
 ```shell
-LATEST_IMAGE=$(docker images | grep osml-viewpoint | awk 'NR==1{print $1":"$2}')
+LATEST_IMAGE=$(docker images | grep osml-tile-server | awk 'NR==1{print $1":"$2}')
 
 docker run \
   -it \

--- a/scripts/run-local-server.sh
+++ b/scripts/run-local-server.sh
@@ -25,6 +25,7 @@ DOCKER_OPTS=(
   --env AWS_ACCESS_KEY_ID
   --env AWS_SECRET_ACCESS_KEY
   --env AWS_SESSION_TOKEN
+  --cap-add SYS_PTRACE \
   --restart "unless-stopped"
   --log-opt max-size=10m --log-opt max-file=3
   --cpus="0.5" --memory="500m"

--- a/test-load/README.md
+++ b/test-load/README.md
@@ -1,0 +1,20 @@
+# Basic Load Testing with Locust
+
+## Quick Start: Local Development Load Testing
+Sample configuration files have been provided to run load tests from a local machine. The `test-load/locust_ts_user.py`
+locustfile contains simulated users of the tile server resources.
+
+1. Create a Conda environment containing the load testing tools. A sample environment has been provided in: `test-load/locust-environment.yaml`
+2. Activate the Conda environment
+3. Run Locust on your local machine and point at your running instance of the Tile Server (see -H option)
+4. Assuming a default configuration the Locust web interface should be available at http://localhost:8089
+
+```shell
+cd test-load
+conda env create -f locust-environment.yaml
+conda activate osml-ts-locust-env
+locust -f locust_ts_user.py -H http://localhost
+```
+
+## References:
+- Locust: https://locust.io

--- a/test-load/locust-environment.yaml
+++ b/test-load/locust-environment.yaml
@@ -7,3 +7,5 @@ dependencies:
   - pip:
       - locust
       - boto3
+      - hilbertcurve
+      - py-spy

--- a/test-load/locust_ts_user.py
+++ b/test-load/locust_ts_user.py
@@ -1,6 +1,7 @@
 import os
 import random
 import time
+from math import ceil, log
 from pathlib import Path
 from secrets import token_hex
 from typing import List, Optional
@@ -8,6 +9,7 @@ from typing import List, Optional
 import boto3
 import gevent
 from botocore.config import Config
+from hilbertcurve.hilbertcurve import HilbertCurve
 from locust import FastHttpUser, between, events, task
 
 VIEWPOINT_STATUS = "viewpoint_status"
@@ -24,17 +26,29 @@ def _(parser):
         default="rawimagery-parrised-devaccount",
         help="Name of bucket containing test imagery",
     )
+    parser.add_argument(
+        "--test-images-prefix",
+        type=str,
+        env_var="LOCUST_TEST_IMAGES_PREFIX",
+        default="",
+        help="Prefix of object keys to test",
+    )
 
 
 @events.test_start.add_listener
 def _(environment, **kwargs):
     print(f"Using imagery from: {environment.parsed_options.test_images_bucket}")
+    print(f"With object Prefix: {environment.parsed_options.test_images_prefix}")
 
 
 class TileServerUser(FastHttpUser):
+    # Establishes a 1-2 second wait between tasks
+    wait_time = between(1, 2)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.test_images_bucket = self.environment.parsed_options.test_images_bucket
+        self.test_images_prefix = self.environment.parsed_options.test_images_prefix or None
         self.test_image_keys = []
 
     def on_start(self):
@@ -45,7 +59,9 @@ class TileServerUser(FastHttpUser):
         s3_client = boto3.client("s3", config=Config(region_name=os.getenv("AWS_DEFAULT_REGION", "us-west-2")))
         paginator = s3_client.get_paginator("list_objects_v2")
         response_iterator = paginator.paginate(
-            Bucket=self.test_images_bucket, PaginationConfig={"MaxItems": 200, "PageSize": 20}
+            Bucket=self.test_images_bucket,
+            Prefix=self.test_images_prefix,
+            PaginationConfig={"MaxItems": 200, "PageSize": 20},
         )
         for response in response_iterator:
             for item in response["Contents"]:
@@ -58,9 +74,6 @@ class TileServerUser(FastHttpUser):
             raise ValueError(f"Unable to find any test imagery in {self.test_images_bucket}")
         else:
             print(f"Found {len(self.test_image_keys)} test images in {self.test_images_bucket}")
-
-    # Establishes a 1-2 second wait between tasks
-    wait_time = between(1, 2)
 
     @task(5)
     def view_new_image_behavior(self) -> None:
@@ -133,24 +146,27 @@ class TileServerUser(FastHttpUser):
                         time.sleep(2)
         return final_status
 
-    def request_tiles(self, viewpoint_id: str):
+    def request_tiles(self, viewpoint_id: str, num_tiles: int = 100, batch_size: int = 5):
         z = 0
         tile_format = "PNG"
         compression = "NONE"
 
-        def concurrent_tile_request(url: str):
+        def concurrent_tile_request(tile: [int, int]):
+            url = f"/viewpoints/{viewpoint_id}/tiles/{z}/{tile[0]}/{tile[1]}.{tile_format}?compression={compression}"
             with self.client.get(url, name="GetTile") as response:
                 if not response.content:
-                    response.failure(f"GetTile response contained no content")
+                    response.failure("GetTile response contained no content")
 
-        pool = gevent.pool.Pool()
-        for y in range(0, 10):
-            for x in range(0, 10):
-                pool.spawn(
-                    concurrent_tile_request,
-                    f"/viewpoints/{viewpoint_id}/tiles/{z}/{x}/{y}.{tile_format}?compression={compression}",
-                )
-        pool.join()
+        p = ceil(log(num_tiles) / (2 * log(2)))
+        n = 2
+        hilbert_curve = HilbertCurve(p, n)
+        for i in range(0, num_tiles, batch_size):
+            distances = list(range(i, i + batch_size))
+            tiles = hilbert_curve.points_from_distances(distances)
+            pool = gevent.pool.Pool()
+            for tile in tiles:
+                pool.spawn(concurrent_tile_request, tile)
+            pool.join()
 
     def cleanup_viewpoint(self, viewpoint_id: str):
         with self.rest("DELETE", f"/viewpoints/{viewpoint_id}", name="DeleteViewpoint") as response:
@@ -161,7 +177,6 @@ class TileServerUser(FastHttpUser):
                     response.failure(f"Unexpected status after viewpoint delete {response.text}")
 
     def list_ready_viewpoints(self) -> List[str]:
-
         result = []
         with self.rest("GET", "/viewpoints", name="ListViewpoints") as response:
             if response.js is not None:
@@ -175,22 +190,22 @@ class TileServerUser(FastHttpUser):
         return result
 
     def get_viewpoint_metadata(self, viewpoint_id: str):
-        with (self.rest("GET", f"/viewpoints/{viewpoint_id}/metadata", name="GetMetadata") as response):
+        with self.rest("GET", f"/viewpoints/{viewpoint_id}/metadata", name="GetMetadata") as response:
             if response.js is not None and "metadata" not in response.js:
                 response.failure(f"'metadata' missing from response {response.text}")
 
     def get_viewpoint_bounds(self, viewpoint_id: str):
-        with (self.rest("GET", f"/viewpoints/{viewpoint_id}/bounds", name="GetBounds") as response):
+        with self.rest("GET", f"/viewpoints/{viewpoint_id}/bounds", name="GetBounds") as response:
             if response.js is not None and "bounds" not in response.js:
                 response.failure(f"'bounds' missing from response {response.text}")
 
     def get_viewpoint_info(self, viewpoint_id: str):
-        with (self.rest("GET", f"/viewpoints/{viewpoint_id}/info", name="GetInfo") as response):
+        with self.rest("GET", f"/viewpoints/{viewpoint_id}/info", name="GetInfo") as response:
             if response.js is not None and "features" not in response.js:
                 response.failure(f"'features' missing from response {response.text}")
 
     def get_viewpoint_statistics(self, viewpoint_id: str):
-        with (self.rest("GET", f"/viewpoints/{viewpoint_id}/statistics", name="GetStatistics") as response):
+        with self.rest("GET", f"/viewpoints/{viewpoint_id}/statistics", name="GetStatistics") as response:
             if response.js is not None and "image_statistics" not in response.js:
                 response.failure(f"'image_statistics' missing from response {response.text}")
 
@@ -198,4 +213,4 @@ class TileServerUser(FastHttpUser):
         tile_format = "PNG"
         with self.client.get(f"/viewpoints/{viewpoint_id}/preview.{tile_format}", name="GetPreview") as response:
             if not response.content:
-                response.failure(f"GetPreview response contained no content")
+                response.failure("GetPreview response contained no content")


### PR DESCRIPTION
Original load test was making 100 concurrent requests for tiles all at the same time. This spiky behavior is not representative of the tile fetch pattern driven by an end user roaming around with a tiled image web application. This change introduces a space filling curve to mimic a user roaming around an image using a web visualization tool. Tiles are fetched in concurrent batches of five from adjacent tiles.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
