### PR TITLE
feat: add tile factory resource pool

### DIFF
--- a/scripts/run-local-server.sh
+++ b/scripts/run-local-server.sh
@@ -21,13 +21,12 @@ fi
 DOCKER_OPTS=(
   --name "$CONTAINER_NAME"
   -p 80:80
-  -v "$(pwd)/local_viewpoint_cache:/tmp/viewpoint:rw"
+  -v "/tmp/local_viewpoint_cache:/tmp/viewpoint:rw"
   --env AWS_ACCESS_KEY_ID
   --env AWS_SECRET_ACCESS_KEY
   --env AWS_SESSION_TOKEN
   --restart "unless-stopped"
   --log-opt max-size=10m --log-opt max-file=3
-  --cpus="0.5" --memory="500m"
 )
 
 docker run "${DOCKER_OPTS[@]}" "${IMAGE_NAME}:${IMAGE_TAG}"

--- a/src/aws/osml/tile_server/main.py
+++ b/src/aws/osml/tile_server/main.py
@@ -37,6 +37,7 @@ app = FastAPI(
         This AWS Content is provided subject to the terms of the AWS Customer Agreement
         available at https://aws.amazon.com/agreement or other written agreement between
         Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.""",
+        "name": "TEST",
     },
 )
 
@@ -124,4 +125,4 @@ async def root() -> str:
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=4557, reload=True)
+    uvicorn.run(app, host="0.0.0.0", port=4557, reload=True, debug=True)

--- a/src/aws/osml/tile_server/utils/__init__.py
+++ b/src/aws/osml/tile_server/utils/__init__.py
@@ -1,3 +1,3 @@
 from .aws_services import initialize_ddb, initialize_s3, initialize_sqs
 from .string_enums import AutoLowerStringEnum, AutoStringEnum, AutoUnderscoreStringEnum
-from .tile_server_utils import get_media_type, get_tile_factory, perform_gdal_translation
+from .tile_server_utils import get_media_type, get_tile_factory_pool, perform_gdal_translation

--- a/src/aws/osml/tile_server/utils/tile_server_utils.py
+++ b/src/aws/osml/tile_server/utils/tile_server_utils.py
@@ -1,4 +1,9 @@
-from functools import cache
+import logging
+import threading
+import time
+from contextlib import contextmanager
+from functools import lru_cache
+from threading import RLock
 from typing import Dict, Optional
 from uuid import uuid4
 
@@ -7,6 +12,8 @@ from osgeo.gdal import Dataset
 
 from aws.osml.gdal import GDALCompressionOptions, GDALImageFormats, RangeAdjustmentType, load_gdal_dataset
 from aws.osml.image_processing import GDALTileFactory
+
+logger = logging.getLogger("uvicorn")
 
 
 def get_media_type(tile_format: GDALImageFormats) -> str:
@@ -27,28 +34,74 @@ def get_media_type(tile_format: GDALImageFormats) -> str:
     return supported_media_types.get(tile_format.lower(), default_media_type)
 
 
-@cache
-def get_tile_factory(
+class TileFactoryPool:
+    def __init__(
+        self,
+        tile_format: GDALImageFormats,
+        tile_compression: GDALCompressionOptions,
+        local_object_path: str,
+        output_type: Optional[int] = None,
+        range_adjustment: RangeAdjustmentType = RangeAdjustmentType.NONE,
+    ):
+        self.lock = RLock()
+        self.current_inventory = []
+        self.total_inventory = 0
+        self.tile_format = tile_format
+        self.tile_compression = tile_compression
+        self.local_object_path = local_object_path
+        self.output_type = output_type
+        self.range_adjustment = range_adjustment
+
+    def checkout(self) -> GDALTileFactory:
+        tf = None
+        with self.lock:
+            if self.current_inventory:
+                tf = self.current_inventory.pop(0)
+
+        if tf is None:
+            thread_id = threading.get_native_id()
+
+            start_time = time.perf_counter()
+            ds, sensor_model = load_gdal_dataset(self.local_object_path)
+            tf = GDALTileFactory(
+                ds, sensor_model, self.tile_format, self.tile_compression, self.output_type, self.range_adjustment
+            )
+            end_time = time.perf_counter()
+            logger.info(
+                f"New TileFactory for {self.local_object_path}"
+                f" created by thread {thread_id} in {end_time - start_time} seconds."
+            )
+
+            with self.lock:
+                self.total_inventory += 1
+                logger.info(f"Total TileFactory count for {self.local_object_path} is {self.total_inventory}")
+
+        return tf
+
+    def checkin(self, tf: GDALTileFactory) -> None:
+        with self.lock:
+            self.current_inventory.append(tf)
+
+    @contextmanager
+    def checkout_in_context(self):
+        tf = None
+        try:
+            tf = self.checkout()
+            yield tf
+        finally:
+            if tf:
+                self.checkin(tf)
+
+
+@lru_cache(maxsize=20)
+def get_tile_factory_pool(
     tile_format: GDALImageFormats,
     tile_compression: GDALCompressionOptions,
     local_object_path: str,
     output_type: Optional[int] = None,
     range_adjustment: RangeAdjustmentType = RangeAdjustmentType.NONE,
-) -> GDALTileFactory:
-    """
-    This function will create a sensor model from a given imagery
-
-    :param tile_format: current status of a viewpoint
-    :param tile_compression: the output tile compression
-    :param local_object_path: the path of an imagery
-    :param output_type: the GDAL pixel type in the output tile
-    :param range_adjustment: the type of scaling used to convert raw pixel values to the output range
-
-    :return: factory capable of producing tiles from a given GDAL raster dataset
-    """
-
-    ds, sensor_model = load_gdal_dataset(local_object_path)
-    return GDALTileFactory(ds, sensor_model, tile_format, tile_compression, output_type, range_adjustment)
+) -> TileFactoryPool:
+    return TileFactoryPool(tile_format, tile_compression, local_object_path, output_type, range_adjustment)
 
 
 def perform_gdal_translation(dataset: Dataset, gdal_options: Dict) -> Optional[bytearray]:

--- a/src/aws/osml/tile_server/viewpoint/database.py
+++ b/src/aws/osml/tile_server/viewpoint/database.py
@@ -89,7 +89,7 @@ class ViewpointStatusTable:
         except Exception as err:
             raise HTTPException(status_code=500, detail=f"Something went wrong with ViewpointStatusTable! Error: {err}")
 
-    async def get_viewpoint(self, viewpoint_id: str) -> ViewpointModel:
+    def get_viewpoint(self, viewpoint_id: str) -> ViewpointModel:
         """
         Get detail of a viewpoint based on a given viewpoint id
 


### PR DESCRIPTION
This update replaces the async resource handlers with synchronous versions that will run in multiple threads pulling tile factories from a resource pool. 

For async to be performant the underlying resources need to participate in the cooperative concurrency model and unfortunately our two most critical dependencies, GDAL and Boto3, do not. The consequence is that on the original implementation all of the GetTile requests are running sequentially on a single thread not giving up their time when blocked on IO. As measured by a simple load test with 5 concurrent users the median get_tile time was 13 seconds and P99 was 100 seconds. This is too slow.

As a first step to fixing this FastAPI would suggest we move away from the async approach and use regular functions for our handlers. (See: [Concurrency and async / await](https://fastapi.tiangolo.com/async/)) The challenge with this is that GDAL itself is not thread safe so the Datasets we have cached will crash the server when used in this way.

This change introduced a tile factory pool so the connections to the underlying dataset can be checked out, used, and returned by individual processing threads as needed. This change dropped the median get_tile time to <3 seconds and the P99 to 24 seconds. There is still room for improvement here but this is a better foundation to build from than the original async approach.

Note that this change also removes the `--cpus="0.5" --memory="500m"` options that were added recently as part of a documentation commit. Those limits are not appropriate for this server and when exceeded cause the server to be killed during processing. We will look to bounding the resources in the future but we're not ready to introduce limits at this time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
