### PR TITLE
feat: download or create aux files for imagery

### DIFF
--- a/scripts/run-local-server.sh
+++ b/scripts/run-local-server.sh
@@ -25,6 +25,9 @@ DOCKER_OPTS=(
   --env AWS_ACCESS_KEY_ID
   --env AWS_SECRET_ACCESS_KEY
   --env AWS_SESSION_TOKEN
+  --env GDAL_CACHEMAX=2048
+  --env GDAL_NUM_THREADS=ALL_CPUS
+  --env WEB_CONCURRENCY=1
   --cap-add SYS_PTRACE \
   --restart "unless-stopped"
   --log-opt max-size=10m --log-opt max-file=3

--- a/src/aws/osml/tile_server/utils/__init__.py
+++ b/src/aws/osml/tile_server/utils/__init__.py
@@ -1,3 +1,3 @@
 from .aws_services import initialize_ddb, initialize_s3, initialize_sqs
 from .string_enums import AutoLowerStringEnum, AutoStringEnum, AutoUnderscoreStringEnum
-from .tile_server_utils import get_media_type, get_tile_factory_pool, perform_gdal_translation
+from .tile_server_utils import get_media_type, get_standard_overviews, get_tile_factory_pool, perform_gdal_translation

--- a/src/aws/osml/tile_server/utils/tile_server_utils.py
+++ b/src/aws/osml/tile_server/utils/tile_server_utils.py
@@ -3,8 +3,9 @@ import threading
 import time
 from contextlib import contextmanager
 from functools import lru_cache
+from math import ceil, log
 from threading import RLock
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 from uuid import uuid4
 
 from osgeo import gdal
@@ -32,6 +33,26 @@ def get_media_type(tile_format: GDALImageFormats) -> str:
     }
     default_media_type = "image"
     return supported_media_types.get(tile_format.lower(), default_media_type)
+
+
+def get_standard_overviews(width: int, height: int, preview_size: int) -> List[int]:
+    """
+    This utility computes a list of reduced resolution scales that define a standard image pyramid for a given
+    image and desired final preview size.
+
+    :param width: width of the full image at highest resolution
+    :param height: height of the full image at highest resolution
+    :param preview_size: the desired size of the lowest resolution / thumbnail image.
+    :return: The list of scale factors needed for each level in the tile pyramid e.g. [2, 4, 8, 16 ...]
+    """
+    min_side = min(width, height)
+    num_overviews = ceil(log(min_side / preview_size) / log(2))
+    if num_overviews > 0:
+        result = []
+        for i in range(1, num_overviews + 1):
+            result.append(2**i)
+        return result
+    return []
 
 
 class TileFactoryPool:

--- a/src/aws/osml/tile_server/viewpoint/worker.py
+++ b/src/aws/osml/tile_server/viewpoint/worker.py
@@ -1,38 +1,47 @@
-import asyncio
 import json
 import logging
-import os
+import threading
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
 
 from boto3.resources.base import ServiceResource
 from botocore.exceptions import ClientError
-from osgeo import gdalconst
+from osgeo import gdal, gdalconst
 
 from aws.osml.gdal import GDALCompressionOptions, GDALImageFormats, RangeAdjustmentType
-from aws.osml.tile_server.utils import get_tile_factory_pool
-
 from aws.osml.tile_server.app_config import ServerConfig
+from aws.osml.tile_server.utils import get_standard_overviews, get_tile_factory_pool
 
 from .database import DecimalEncoder, ViewpointStatusTable
 from .models import ViewpointModel, ViewpointStatus
 from .queue import ViewpointRequestQueue
 
+OVERVIEW_FILE_EXTENSION = ".ovr"
+AUXXML_FILE_EXTENSION = ".aux.xml"
 
-class ViewpointWorker:
+
+class ViewpointWorker(threading.Thread):
     def __init__(
         self,
         viewpoint_request_queue: ViewpointRequestQueue,
         aws_s3: ServiceResource,
         viewpoint_database: ViewpointStatusTable,
     ):
+        super().__init__()
+        self.daemon = True
         self.viewpoint_request_queue = viewpoint_request_queue
         self.s3 = aws_s3
         self.viewpoint_database = viewpoint_database
         self.logger = logging.getLogger("uvicorn")
+        self.stopevent = threading.Event()
 
-    async def run(self) -> None:
+    def join(self, timeout: float | None = ...) -> None:
+        self.logger.info("ViewpointWorker Background Thread Stopping.")
+        self.stopevent.set()
+        threading.Thread.join(self, timeout)
+
+    def run(self) -> None:
         """
         Monitors SQS queues for ViewpointRequest and be able to process it. First, it will
         pick up a message from ViewpointRequest SQS. Then, it will download an image from S3
@@ -41,7 +50,8 @@ class ViewpointWorker:
 
         :return: None
         """
-        while True:
+        self.logger.info("ViewpointWorker Background Thread Started.")
+        while not self.stopevent.is_set():
             self.logger.debug("Scanning for SQS messages")
             try:
                 messages = self.viewpoint_request_queue.queue.receive_messages(WaitTimeSeconds=5)
@@ -51,118 +61,31 @@ class ViewpointWorker:
                     message_attributes = json.loads(message.body)
                     viewpoint_item = ViewpointModel.model_validate_json(json.dumps(message_attributes, cls=DecimalEncoder))
 
-                    viewpoint_new_status = ViewpointStatus.REQUESTED
-
-                    message_viewpoint_id = viewpoint_item.viewpoint_id
-                    message_viewpoint_status = viewpoint_item.viewpoint_status
-                    message_object_key = viewpoint_item.object_key
-                    message_bucket_name = viewpoint_item.bucket_name
-
-                    if message_viewpoint_status == ViewpointStatus.REQUESTED:
-                        # create a temp file
-                        local_viewpoint_folder = Path("/" + ServerConfig.efs_mount_name, message_viewpoint_id)
-                        local_viewpoint_folder.mkdir(parents=True, exist_ok=True)
-                        local_object_path = Path(local_viewpoint_folder, Path(message_object_key).name)
-                        local_object_path_str = str(local_object_path.absolute())
-
-                        # download file to temp local (TODO update when efs is implemented)
-                        retry_count = 0
-                        error_message = None
-                        while retry_count < 3:
-                            try:
-                                self.s3.meta.client.download_file(
-                                    message_bucket_name, message_object_key, local_object_path_str
-                                )
-
-                                viewpoint_new_status = ViewpointStatus.READY
-                                self.logger.info(f"Successfully download to {local_object_path_str}.")
-
-                                error_message = None
-
-                                break
-
-                            except ClientError as err:
-                                if err.response["Error"]["Code"] == "404":
-                                    error_message = f"The {message_bucket_name} bucket does not exist! Error={err}"
-                                    self.logger.error(error_message)
-
-                                elif err.response["Error"]["Code"] == "403":
-                                    error_message = (
-                                        f"You do not have permission to access {message_bucket_name} bucket! Error={err}"
-                                    )
-                                    self.logger.error(error_message)
-
-                                error_message = f"Image Tile Server cannot process your S3 request! Error={err}"
-                                self.logger.error(error_message)
-                                viewpoint_new_status = ViewpointStatus.FAILED
-
-                                break
-                            except Exception as err:
-                                error_message = f"Something went wrong! Viewpoint_id: {message_viewpoint_id}! Error={err}"
-                                self.logger.error(error_message)
-                                viewpoint_new_status = ViewpointStatus.FAILED
-
-                            retry_count += 1
-
-                        try:
-                            self.logger.info(f"Verifying tile creation for {local_object_path_str}.")
-                            tile_format = GDALImageFormats.PNG
-                            compression = GDALCompressionOptions.NONE
-
-                            output_type = None
-                            if viewpoint_item.range_adjustment is not RangeAdjustmentType.NONE:
-                                output_type = gdalconst.GDT_Byte
-
-                            tile_factory_pool = get_tile_factory_pool(
-                                tile_format,
-                                compression,
-                                local_object_path_str,
-                                output_type,
-                                viewpoint_item.range_adjustment,
-                            )
-                            with tile_factory_pool.checkout_in_context() as tile_factory:
-                                start_time = time.perf_counter()
-                                tile_size = viewpoint_item.tile_size
-                                image_bytes = tile_factory.create_encoded_tile([0, 0, tile_size, tile_size])
-                                end_time = time.perf_counter()
-                                self.logger.info(
-                                    f"METRIC: Sample TileCreate Time: {end_time - start_time}"
-                                    f" for {local_object_path_str}"
-                                )
-
-                                if not image_bytes:
-                                    error_message = f"Unable to create valid tile for viewpoint: {message_viewpoint_id}"
-                                    self.logger.error(error_message)
-                                    viewpoint_new_status = ViewpointStatus.FAILED
-
-                        except Exception as err:
-                            error_message = (
-                                f"Unable to create sample tile for! Viewpoint_id: {message_viewpoint_id}! Error={err}"
-                            )
-                            self.logger.error(error_message)
-                            viewpoint_new_status = ViewpointStatus.FAILED
-
-                        # update ddb
-                        viewpoint_item.viewpoint_status = viewpoint_new_status
-                        if viewpoint_new_status is ViewpointStatus.FAILED:
-                            time_now = datetime.utcnow()
-                            expire_time = time_now + timedelta(1)
-                            viewpoint_item.expire_time = int(expire_time.timestamp())
-                        viewpoint_item.local_object_path = local_object_path_str
-
-                        if error_message:
-                            viewpoint_item.error_message = error_message
-
-                        self.viewpoint_database.update_viewpoint(viewpoint_item)
-
-                        # remove message from the queue since it has been processed
-                        message.delete()
-                    else:
+                    if viewpoint_item.viewpoint_status != ViewpointStatus.REQUESTED:
                         self.logger.error(
-                            f"Cannot process {message_viewpoint_id} due to the incorrect "
-                            f"Viewpoint Status {message_viewpoint_status}!"
+                            f"Cannot process {viewpoint_item.viewpoint_id} due to the incorrect "
+                            f"Viewpoint Status {viewpoint_item.viewpoint_status}!"
                         )
                         continue
+
+                    if viewpoint_item.viewpoint_status != ViewpointStatus.FAILED:
+                        self.download_image(viewpoint_item)
+
+                    if viewpoint_item.viewpoint_status != ViewpointStatus.FAILED:
+                        self.create_tile_pyramid(viewpoint_item)
+
+                    # update ddb
+                    if viewpoint_item.viewpoint_status == ViewpointStatus.FAILED:
+                        time_now = datetime.utcnow()
+                        expire_time = time_now + timedelta(1)
+                        viewpoint_item.expire_time = int(expire_time.timestamp())
+                    else:
+                        viewpoint_item.viewpoint_status = ViewpointStatus.READY
+
+                    self.viewpoint_database.update_viewpoint(viewpoint_item)
+
+                    # remove message from the queue since it has been processed
+                    message.delete()
 
             except ClientError as err:
                 self.logger.warning(f"[Worker Background Thread] {err}")
@@ -171,4 +94,148 @@ class ViewpointWorker:
             except Exception as err:
                 self.logger.warning(f"[Worker Background Thread] {err}")
 
-            await asyncio.sleep(1)
+    def download_image(self, viewpoint_item):
+        message_viewpoint_id = viewpoint_item.viewpoint_id
+        message_object_key = viewpoint_item.object_key
+        message_bucket_name = viewpoint_item.bucket_name
+
+        # create a temp file
+        self.logger.info(f"Creating local directory for {message_viewpoint_id} in /{ServerConfig.efs_mount_name}")
+        local_viewpoint_folder = Path("/" + ServerConfig.efs_mount_name, message_viewpoint_id)
+        local_viewpoint_folder.mkdir(parents=True, exist_ok=True)
+        local_object_path = Path(local_viewpoint_folder, Path(message_object_key).name)
+        local_object_path_str = str(local_object_path.absolute())
+        viewpoint_item.local_object_path = local_object_path_str
+
+        # download file to temp local (TODO update when efs is implemented)
+        retry_count = 0
+        while retry_count < 3:
+            try:
+                self.logger.info(f"Beginning download of {message_viewpoint_id}")
+                self.s3.meta.client.download_file(message_bucket_name, message_object_key, local_object_path_str)
+                self.logger.info(f"Successfully download to {local_object_path_str}.")
+                break
+
+            except ClientError as err:
+                if err.response["Error"]["Code"] == "404":
+                    error_message = f"The {message_bucket_name} bucket does not exist! Error={err}"
+                    self.logger.error(error_message)
+
+                elif err.response["Error"]["Code"] == "403":
+                    error_message = f"You do not have permission to access {message_bucket_name} bucket! Error={err}"
+                    self.logger.error(error_message)
+
+                error_message = f"Image Tile Server cannot process your S3 request! Error={err}"
+                self.logger.error(error_message)
+                viewpoint_item.viewpoint_status = ViewpointStatus.FAILED
+                viewpoint_item.error_message = error_message
+                break
+            except Exception as err:
+                error_message = f"Something went wrong! Viewpoint_id: {message_viewpoint_id}! Error={err}"
+                self.logger.error(error_message)
+                viewpoint_item.viewpoint_status = ViewpointStatus.FAILED
+                viewpoint_item.error_message = error_message
+
+            retry_count += 1
+
+        if viewpoint_item.viewpoint_status != ViewpointStatus.FAILED:
+            try:
+                self.logger.info(f"Attempting to download optional overviews for {message_viewpoint_id}")
+                self.s3.meta.client.download_file(
+                    message_bucket_name,
+                    message_object_key + OVERVIEW_FILE_EXTENSION,
+                    local_object_path_str + OVERVIEW_FILE_EXTENSION,
+                )
+                self.logger.info(f"Successfully downloaded overviews to {local_object_path_str + OVERVIEW_FILE_EXTENSION}.")
+            except ClientError:
+                self.logger.info(f"No overviews available for {message_viewpoint_id}")
+
+            try:
+                self.logger.info(f"Attempting to download optional aux file for {message_viewpoint_id}")
+                self.s3.meta.client.download_file(
+                    message_bucket_name,
+                    message_object_key + AUXXML_FILE_EXTENSION,
+                    local_object_path_str + AUXXML_FILE_EXTENSION,
+                )
+                self.logger.info(f"Successfully download aux file to {local_object_path_str + AUXXML_FILE_EXTENSION}.")
+            except ClientError:
+                self.logger.info(f"No aux file available for {message_viewpoint_id}")
+
+    def create_tile_pyramid(self, viewpoint_item):
+        try:
+            tile_format = GDALImageFormats.PNG
+            compression = GDALCompressionOptions.NONE
+
+            output_type = None
+            if viewpoint_item.range_adjustment is not RangeAdjustmentType.NONE:
+                output_type = gdalconst.GDT_Byte
+
+            tile_factory_pool = get_tile_factory_pool(
+                tile_format,
+                compression,
+                viewpoint_item.local_object_path,
+                output_type,
+                viewpoint_item.range_adjustment,
+            )
+
+            aux_file_path = Path(viewpoint_item.local_object_path + AUXXML_FILE_EXTENSION)
+            overview_file_path = Path(viewpoint_item.local_object_path + OVERVIEW_FILE_EXTENSION)
+
+            # This code forces GDAL to and compute the statistics / histograms for each band.
+            #
+            # This can be a time-consuming operation, so we want to only do this once. GDAL will write those
+            # statistics into a .aux.xml file associated with the dataset but it only appears to do so when the
+            # dataset object is cleaned up. So this code creates a temporary dataset, forces it to generate the
+            # statistics using the gdal.Info() command and then closes the dataset to ensure that the auxiliary
+            # file is created. This is somewhat of a hack but all future calls to gdal.Open (i.e. in the tile
+            # factory pool) should be able to read the .aux.xml file and skip the expensive work of generating
+            # the statistics.
+            if not self.stopevent.is_set() and not aux_file_path.is_file():
+                self.logger.info(f"Calculating Image Statistics for {viewpoint_item.local_object_path}")
+                start_time = time.perf_counter()
+                temp_ds = gdal.Open(viewpoint_item.local_object_path)
+                gdal.Info(temp_ds, stats=True, approxStats=True, computeMinMax=True, reportHistograms=True)
+                del temp_ds
+                end_time = time.perf_counter()
+                self.logger.info(
+                    f"METRIC: GDAL Info Time: {end_time - start_time}" f" for {viewpoint_item.local_object_path}"
+                )
+
+            start_time = time.perf_counter()
+            with tile_factory_pool.checkout_in_context() as tile_factory:
+                end_time = time.perf_counter()
+                self.logger.info(
+                    f"METRIC: TileFactory Create Time: {end_time - start_time}" f" for {viewpoint_item.local_object_path}"
+                )
+
+                if not self.stopevent.is_set() and not overview_file_path.is_file():
+                    self.logger.info(f"Creating Image Pyramid for {viewpoint_item.local_object_path}")
+                    start_time = time.perf_counter()
+                    ds = tile_factory.raster_dataset
+                    overviews = get_standard_overviews(ds.RasterXSize, ds.RasterYSize, 1024)
+                    ds.BuildOverviews("CUBIC", overviews)
+                    end_time = time.perf_counter()
+                    self.logger.info(
+                        f"METRIC: BuildOverviews Time: {end_time - start_time}" f" for {viewpoint_item.local_object_path}"
+                    )
+
+                self.logger.info(f"Verifying tile creation for {viewpoint_item.local_object_path}.")
+                start_time = time.perf_counter()
+                tile_size = viewpoint_item.tile_size
+                image_bytes = tile_factory.create_encoded_tile([0, 0, tile_size, tile_size])
+                end_time = time.perf_counter()
+                self.logger.info(
+                    f"METRIC: Sample TileCreate Time: {end_time - start_time}" f" for {viewpoint_item.local_object_path}"
+                )
+
+                if not image_bytes:
+                    error_message = f"Unable to create valid tile for viewpoint: {viewpoint_item.viewpoint_id}"
+                    self.logger.error(error_message)
+                    viewpoint_item.viewpoint_status = ViewpointStatus.FAILED
+                    viewpoint_item.error_message = error_message
+
+        except Exception as err:
+            error_message = f"Unable to create sample tile for! Viewpoint_id: {viewpoint_item.viewpoint_id}! Error={err}"
+            self.logger.error(error_message)
+            viewpoint_item.viewpoint_status = ViewpointStatus.FAILED
+            viewpoint_item.error_message = error_message


### PR DESCRIPTION
These changes make GDALs auxiliary statistics (.aux.xml) and overviews (.ovr) available for all images. These files are necessary to produce visualization tiles quickly (i.e. DRA calculations or other zoom levels) but they are expensive to create for large NITF images (2-5 minutes each). The worker first checks to see if they are available in S3 and if so it downloads them after the image is downloaded. If not the files are generated as part of the background process. Ideally these files will be created by the image ingest process that puts the images in S3. If not the tile server will handle it but the CreateViewpoint request will take longer to reach the READY state.

Note that this extra processing revealed that an async background task interferes with the regular web dispatch calls. I updated the background worker to be a regular Python thread that is stopped and started as part of the FastAPI application lifecycle. This lifecycle based approach is recommended over the deprecated startup/shutdown events used originally.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
