### PR TITLE
feat: add ability to generate reduced resolution tiles

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     starlette[full]
     cryptography
     boto3
-    osml-imagery-toolkit>=1.1.2
+    osml-imagery-toolkit>=1.2
 
 [options.packages.find]
 where = src

--- a/test-load/README.md
+++ b/test-load/README.md
@@ -13,7 +13,7 @@ locustfile contains simulated users of the tile server resources.
 cd test-load
 conda env create -f locust-environment.yaml
 conda activate osml-ts-locust-env
-locust -f locust_ts_user.py -H http://localhost
+locust -f locust_ts_user.py -H http://localhost:8080/v1_0
 ```
 
 ## References:


### PR DESCRIPTION
This update enables the z coordinate on the <viewpoint_id>/tiles API allowing users to request reduced resolution tiles. Note that the z coordinate is not a map zoom level; it is the resolution level in the image pyramid (r-level) where 0 is the full resolution image, 1 is the next level up reducing the width and height by a factor of 2, etc. 

The key processing is contained in the osml-imagery-toolkit and this application has been updated to require >=v1.2.0 to incorporate this necessary functionality.

The load tests were updated to fetch tiles from a variety of resolution levels and verify that thanks to the pre-computed overviews the response times remain consistent independent of r-level.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
