### PR TITLE
feat: change preview API parameters and provide defaults

### DIFF
--- a/test-load/locust_ts_user.py
+++ b/test-load/locust_ts_user.py
@@ -148,7 +148,7 @@ class TileServerUser(FastHttpUser):
             self.get_viewpoint_metadata(viewpoint_id)
             self.get_viewpoint_info(viewpoint_id)
             self.get_viewpoint_bounds(viewpoint_id)
-            # self.get_viewpoint_preview(viewpoint_id)  # TODO: Reenable Preview once it isn't super slow
+            self.get_viewpoint_preview(viewpoint_id)
             self.get_viewpoint_statistics(viewpoint_id)
 
         pool = gevent.pool.Pool()
@@ -260,7 +260,7 @@ class TileServerUser(FastHttpUser):
         result = []
         with self.rest("GET", "/viewpoints", name="ListViewpoints") as response:
             if response.js is not None:
-                for viewpoint in response.js:
+                for viewpoint in response.js["items"]:
                     if (
                         VIEWPOINT_ID in viewpoint
                         and VIEWPOINT_STATUS in viewpoint


### PR DESCRIPTION
These changes update the preview API parameters to be similar to that of the [TiTiler COG preview API.](https://developmentseed.org/titiler/endpoints/cog/#preview) and setting default values such that if a user requests a <viewpoint_id>/preview.PNG they get an image with a max size of 1024. Specifically this replaces the scale and x_px, y_px parameters with a max_size, width, and height parameters which are all optional.

Internally this change makes the preview API now use the TileFactoryPool to minimize the number of times the dataset needs to be opened. 

This change also adds calls to preview back into the regular load tests now that the standard response time is inline with other operations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
