### PR TITLE
fix: create viewpoints with existing external overview file

### DIFF
--- a/src/aws/osml/tile_server/viewpoint/worker.py
+++ b/src/aws/osml/tile_server/viewpoint/worker.py
@@ -18,6 +18,7 @@ from botocore.exceptions import ClientError
 from osgeo import gdal, gdalconst
 
 from aws.osml.gdal import GDALCompressionOptions, GDALImageFormats, RangeAdjustmentType
+from aws.osml.image_processing import GDALTileFactory
 from aws.osml.photogrammetry import ImageCoordinate
 from aws.osml.tile_server.app_config import ServerConfig
 from aws.osml.tile_server.utils import (
@@ -161,10 +162,10 @@ class ViewpointWorker(Thread):
                     f"METRIC: TileFactory Create Time: {end_time - start_time} for {viewpoint_item.local_object_path}"
                 )
 
-                image_bytes = None
                 if not self.stop_event.is_set() and not overview_file_path.is_file():
                     self._create_image_pyramid(tile_factory, viewpoint_item)
-                    image_bytes = self._verify_tile_creation(tile_factory, viewpoint_item)
+
+                image_bytes = self._verify_tile_creation(tile_factory, viewpoint_item)
 
                 if not image_bytes:
                     raise ValueError("Image is empty.")
@@ -400,7 +401,7 @@ class ViewpointWorker(Thread):
         end_time = time.perf_counter()
         self.logger.info(f"METRIC: BuildOverviews Time: {end_time - start_time}" f" for {viewpoint_item.local_object_path}")
 
-    def _verify_tile_creation(self, tile_factory: TileFactoryPool, viewpoint_item: ViewpointModel) -> bytes:
+    def _verify_tile_creation(self, tile_factory: GDALTileFactory, viewpoint_item: ViewpointModel) -> bytes:
         self.logger.info(f"Verifying tile creation for {viewpoint_item.local_object_path}.")
         start_time = time.perf_counter()
         tile_size = viewpoint_item.tile_size


### PR DESCRIPTION
This change fixes a bug in the current viewpoint create API. 

In the current implementation if a user attempts to create a viewpoint using a file that already has a set of external overviews (i.e. an .ovr file that was downloaded from S3 rather than created as part of the worker thread) then the call to verify that a tile can be created from the image (`_verify_tile_creation(...)` is never made. That will eventually fail the create. 

This change ensures that the verify tile creation call happens in cases where the .over is created and if it was downloaded from S3. The change also fixes a type hint error in the same section of code that was not impacting the running system.

_Note: that this service does not currently have unit tests that verify these behaviors. Testing was completed using the integration / load tests implemented in osml-tile-server-test._

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
