### PR TITLE
fix: update delete_viewpoint endpoint to actively delete instead of relying on TTL

### DIFF
--- a/src/aws/osml/tile_server/viewpoint/database.py
+++ b/src/aws/osml/tile_server/viewpoint/database.py
@@ -197,6 +197,28 @@ class ViewpointStatusTable:
                 status_code=500, detail=f"Something went wrong when updating an item in ViewpointStatusTable! Error: {err}"
             )
 
+    def delete_viewpoint(self, viewpoint_id: str) -> str:
+        """
+        Delete a viewpoint from the DynamoDB table.
+
+        :param viewpoint_id: The ID of the viewpoint to be deleted.
+        :return: the viewpoint_id of the deleted viewpoint.
+        :raises HTTPException: If an error occurs while deleting the viewpoint.
+        """
+        try:
+            self.table.delete_item(Key={"viewpoint_id": viewpoint_id})
+            return viewpoint_id
+        except ClientError as err:
+            raise HTTPException(
+                status_code=err.response["Error"]["Code"],
+                detail=f"Cannot delete viewpoint from ViewpointStatusTable, error: {err.response['Error']['Message']}",
+            )
+        except Exception as err:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Something went wrong when deleting a viewpoint from ViewpointStatusTable! Error: {err}",
+            )
+
     @staticmethod
     def get_update_params(body: Dict) -> Tuple[str, Dict[str, Any]]:
         """

--- a/test/aws/osml/tile_server/viewpoint/test_routers.py
+++ b/test/aws/osml/tile_server/viewpoint/test_routers.py
@@ -14,8 +14,6 @@ from fastapi.testclient import TestClient
 from moto import mock_aws
 from test_config import TestConfig
 
-from aws.osml.tile_server.viewpoint.models import ViewpointStatus
-
 TEST_INVALID_VIEWPOINT_ID = "invalid-viewpoint-id"
 
 TEST_BODY = {
@@ -263,9 +261,7 @@ class TestRoutersE2E(TestCase):
         viewpoint_id = self.mock_create_viewpoint()
         response = self.client.delete(f"/latest/viewpoints/{viewpoint_id}")
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["viewpoint_status"], ViewpointStatus.DELETED)
-        self.assertIsNone(response.json()["local_object_path"])
+        self.assertEqual(response.status_code, 204)
 
     def test_e2e_update_viewpoint_valid(self):
         """Test updating a valid viewpoint."""


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
This change actively deletes a viewpoint from the database when the delete viewpoint endpoint is called instead of setting the state to DELETED and letting TTL perform the cleanup.  Since viewpoint IDs are now client defined this provides a more natural interaction with viewpoints.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
