### PR TITLE
fix: change viewpoint StreamingResponse to Response

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,13 +31,11 @@ install_requires =
     fastapi
     fastapi-versioning
     asgi-correlation-id
-    starlette[full]
     cryptography
     boto3
     geojson>=3.0.0
-    pydantic>=2.0.0
     python-json-logger>=2.0.0
-    osml-imagery-toolkit>=1.4.0rc2
+    osml-imagery-toolkit>=1.4.0rc4
 
 [options.packages.find]
 where = src

--- a/tox.ini
+++ b/tox.ini
@@ -16,20 +16,22 @@ envlist =
 # Pre distribution checks for the package
     twine
 
-requires = tox-conda
+requires =
+    tox-conda
+    setuptools
 skip_missing_interpreters = False
 
 [testenv]
 conda_env = {toxinidir}/conda/environment.yml
 deps =
-    prod: osml-imagery-toolkit
     dev: ../osml-imagery-toolkit
     pytest>=7.2.0
     pytest-cov>=4.0.0
     pytest-xdist>=3.2.0
-    pytest-asyncio>=0.20.3
+    pytest-asyncio>=0.24.0
     mock>=5.0.0
     moto[all]>=5.0.0
+    httpx
 setenv =
     # MOTO/BOTO
     AWS_DEFAULT_REGION=us-west-2


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
This PR updates Tile Server to use Response returns instead of StreamingResponse to be compatible with AWS API Gateway.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
