### PR TITLE
feat: caching of map and image tiles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,8 @@ repos:
         args: ["--max-line-length=125", "--max-complexity=10"]
         types: [file, python]
 
-  - repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v2.0.1
+  - repo: https://github.com/hhatto/autopep8
+    rev: v2.3.2
     hooks:
       - id: autopep8
         args:

--- a/src/aws/osml/tile_server/services/__init__.py
+++ b/src/aws/osml/tile_server/services/__init__.py
@@ -1,6 +1,7 @@
-#  Copyright 2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2024-2025 Amazon.com, Inc. or its affiliates.
 
 from .aws_services import AwsServices, RefreshableBotoSession, get_aws_services
 from .database import DecimalEncoder, ViewpointStatusTable
 from .queue import ViewpointRequestQueue
+from .tile_provider import TileProvider, get_tile_provider
 from .token import get_encryptor, initialize_token_key, read_token_key

--- a/src/aws/osml/tile_server/services/tile_provider.py
+++ b/src/aws/osml/tile_server/services/tile_provider.py
@@ -1,0 +1,126 @@
+#  Copyright 2024-2025 Amazon.com, Inc. or its affiliates.
+
+import logging
+import os
+from functools import lru_cache
+from typing import Optional
+
+from osgeo import gdalconst
+
+from aws.osml.gdal import GDALCompressionOptions, GDALImageFormats, RangeAdjustmentType
+from aws.osml.image_processing import MapTileId, MapTileSetFactory
+from aws.osml.tile_server.utils import get_tile_factory_pool
+
+logger = logging.getLogger(__name__)
+
+
+def get_cached_tile_count() -> int:
+    """
+    This function determines the number of tiles to cache. The value can be overridden by setting the
+    TILE_PROVIDER_CACHED_TILE_COUNT envrionment variable.
+
+    :return: the number of tiles to cache
+    """
+    cached_tile_count_env = "TILE_PROVIDER_CACHED_TILE_COUNT"
+    cached_tile_count_default = 400
+    cached_tile_count = os.getenv(cached_tile_count_env)
+    if cached_tile_count:
+        try:
+            return int(cached_tile_count)
+        except ValueError:
+            logger.warning(
+                f"Invalid {cached_tile_count_env} environment variable. Using default: {cached_tile_count_default}"
+            )
+    return cached_tile_count_default
+
+
+class TileProvider:
+    """
+    The tile provider is a service that creates imagery or map tiles as needed. It is responsible for caching
+    duplicative requests to minimize unnecessary processing.
+    """
+
+    @lru_cache(maxsize=get_cached_tile_count())
+    def get_image_tile(
+        self,
+        local_object_path: str,
+        tile_size: int,
+        z: int,
+        y: int,
+        x: int,
+        tile_format: GDALImageFormats,
+        compression: GDALCompressionOptions,
+        range_adjustment: RangeAdjustmentType,
+    ) -> Optional[bytearray]:
+        """
+        Retrieves and unwarped image tile of the requested size encoded using the format/compression selected.
+        If a range adjustment is specified the image will be preprocessed to an 8 bit per band result using
+        the algorithm requested.
+
+        Note that this method will attempt to respond to duplicative requests using previously computed results.
+
+        :param local_object_path: path to the local image file
+        :param tile_size: size of the tile in pixels
+        :param z: resolution-level in the image pyramid 0 = full resolution, 1 = full/2, 2 = full/4, ...
+        :param y: tile row in the image pyramid
+        :param x: tile column in the image pyramid
+        :param tile_format: image format for the output tile
+        :param compression: compression to use with the output tile; must be compatible with format
+        :param range_adjustment: type of pixel range adjustment to apply
+        :return: the encoded image tile
+        """
+        output_type = None
+        if range_adjustment is not RangeAdjustmentType.NONE:
+            output_type = gdalconst.GDT_Byte
+
+        tile_factory_pool = get_tile_factory_pool(tile_format, compression, local_object_path, output_type, range_adjustment)
+
+        with tile_factory_pool.checkout_in_context() as tile_factory:
+            if tile_factory is None:
+                raise Exception(f"Unable to read tiles from viewpoint {local_object_path}")
+
+            src_tile_size = 2**z * tile_size
+            image_bytes = tile_factory.create_encoded_tile(
+                src_window=[x * src_tile_size, y * src_tile_size, src_tile_size, src_tile_size],
+                output_size=(tile_size, tile_size),
+            )
+
+        return image_bytes
+
+    @lru_cache(maxsize=get_cached_tile_count())
+    def get_map_tile(
+        self,
+        local_object_path: str,
+        tile_matrix_set_id: str,
+        tile_matrix: int,
+        tile_row: int,
+        tile_col: int,
+        tile_format: GDALImageFormats,
+        compression: GDALCompressionOptions,
+        range_adjustment: RangeAdjustmentType,
+    ) -> Optional[bytearray]:
+        output_type = None
+        if range_adjustment is not RangeAdjustmentType.NONE:
+            output_type = gdalconst.GDT_Byte
+
+        tile_factory_pool = get_tile_factory_pool(tile_format, compression, local_object_path, output_type, range_adjustment)
+
+        with tile_factory_pool.checkout_in_context() as tile_factory:
+            if tile_factory is None:
+                raise Exception(f"Unable to read tiles from viewpoint {local_object_path}")
+
+            # Find the tile in the named tileset
+            tile_set = MapTileSetFactory.get_for_id(tile_matrix_set_id)
+            if not tile_set:
+                raise ValueError(f"Unsupported tile set: {tile_matrix_set_id}")
+            tile_id = MapTileId(tile_matrix=tile_matrix, tile_row=tile_row, tile_col=tile_col)
+            tile = tile_set.get_tile(tile_id)
+
+            # Create an orthophoto for this tile
+            image_bytes = tile_factory.create_orthophoto_tile(geo_bbox=tile.bounds, tile_size=tile.size)
+
+        return image_bytes
+
+
+def get_tile_provider() -> TileProvider:
+    return TileProvider()

--- a/src/aws/osml/tile_server/viewpoint/viewpoint_id/image/tiles.py
+++ b/src/aws/osml/tile_server/viewpoint/viewpoint_id/image/tiles.py
@@ -1,14 +1,13 @@
-#  Copyright 2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2024-2025 Amazon.com, Inc. or its affiliates.
 
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response, status
-from osgeo import gdalconst
 
-from aws.osml.gdal import GDALCompressionOptions, GDALImageFormats, RangeAdjustmentType
+from aws.osml.gdal import GDALCompressionOptions, GDALImageFormats
 from aws.osml.tile_server.models import ViewpointApiNames, validate_viewpoint_status
-from aws.osml.tile_server.services import get_aws_services
-from aws.osml.tile_server.utils import get_media_type, get_tile_factory_pool
+from aws.osml.tile_server.services import AwsServices, TileProvider, get_aws_services, get_tile_provider
+from aws.osml.tile_server.utils import get_media_type
 
 tiles_router = APIRouter(
     prefix="/tiles",
@@ -23,7 +22,8 @@ def get_image_tile(
     z: int,
     x: int,
     y: int,
-    aws: Annotated[get_aws_services, Depends()],
+    aws: Annotated[AwsServices, Depends(get_aws_services)],
+    tile_provider: Annotated[TileProvider, Depends(get_tile_provider)],
     tile_format: GDALImageFormats = Path(description="Output image type."),
     compression: GDALCompressionOptions = Query(GDALCompressionOptions.NONE, description="Compression Algorithm for image."),
 ) -> Response:
@@ -31,6 +31,7 @@ def get_image_tile(
     Create a tile of this image using the options set when creating the viewpoint.
 
     :param aws: Injected AWS services.
+    :param tile_provider: Injected tile provider.
     :param viewpoint_id: Unique viewpoint id to get from the table.
     :param z: Resolution-level in the image pyramid 0 = full resolution, 1 = full/2, 2 = full/4, ...
     :param x: Tile row location in pixels for the given tile.
@@ -48,26 +49,25 @@ def get_image_tile(
         viewpoint_item = aws.viewpoint_database.get_viewpoint(viewpoint_id)
         validate_viewpoint_status(viewpoint_item.viewpoint_status, ViewpointApiNames.TILE)
 
-        output_type = None
-        if viewpoint_item.range_adjustment is not RangeAdjustmentType.NONE:
-            output_type = gdalconst.GDT_Byte
-        tile_factory_pool = get_tile_factory_pool(
-            tile_format, compression, viewpoint_item.local_object_path, output_type, viewpoint_item.range_adjustment
+        image_bytes = tile_provider.get_image_tile(
+            viewpoint_item.local_object_path,
+            viewpoint_item.tile_size,
+            z,
+            y,
+            x,
+            tile_format,
+            compression,
+            viewpoint_item.range_adjustment,
         )
-        with tile_factory_pool.checkout_in_context() as tile_factory:
-            if tile_factory is None:
-                raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail=f"Unable to read tiles from viewpoint {viewpoint_item.viewpoint_id}",
-                )
-
-            tile_size = viewpoint_item.tile_size
-            src_tile_size = 2**z * tile_size
-            image_bytes = tile_factory.create_encoded_tile(
-                src_window=[x * src_tile_size, y * src_tile_size, src_tile_size, src_tile_size],
-                output_size=(tile_size, tile_size),
-            )
-        return Response(content=bytes(image_bytes), media_type=get_media_type(tile_format), status_code=status.HTTP_200_OK)
+        headers = {"Cache-Control": "private, max-age=604800"}
+        return Response(
+            content=bytes(image_bytes),
+            media_type=get_media_type(tile_format),
+            status_code=status.HTTP_200_OK,
+            headers=headers,
+        )
+    except ValueError as err:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Failed to fetch tile. Invalid request. {err}")
     except Exception as err:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to fetch tile for image. {err}"

--- a/src/aws/osml/tile_server/viewpoint/viewpoint_id/map/tileset/tile.py
+++ b/src/aws/osml/tile_server/viewpoint/viewpoint_id/map/tileset/tile.py
@@ -1,15 +1,13 @@
-#  Copyright 2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2024-2025 Amazon.com, Inc. or its affiliates.
 
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response, status
-from osgeo import gdalconst
 
-from aws.osml.gdal import GDALCompressionOptions, GDALImageFormats, RangeAdjustmentType
-from aws.osml.image_processing import MapTileId, MapTileSetFactory
+from aws.osml.gdal import GDALCompressionOptions, GDALImageFormats
 from aws.osml.tile_server.models import ViewpointApiNames, validate_viewpoint_status
-from aws.osml.tile_server.services import get_aws_services
-from aws.osml.tile_server.utils import get_media_type, get_tile_factory_pool
+from aws.osml.tile_server.services import get_aws_services, get_tile_provider
+from aws.osml.tile_server.utils import get_media_type
 
 
 def _invert_tile_row_index(tile_row: int, tile_matrix: int) -> int:
@@ -27,6 +25,7 @@ tile_matrix_router = APIRouter(
 @tile_matrix_router.get("/{tile_row}/{tile_col}.{tile_format}")
 def get_map_tile(
     aws: Annotated[get_aws_services, Depends()],
+    tile_provider: Annotated[get_tile_provider, Depends()],
     viewpoint_id: str,
     tile_matrix_set_id: str,
     tile_matrix: int,
@@ -41,6 +40,7 @@ def get_map_tile(
     for the requested tile. This endpoint conforms to the OGC API - Tiles specification.
 
     :param aws: Injected AWS services.
+    :param tile_provider: Injected tile provider.
     :param viewpoint_id: The viewpoint id.
     :param tile_matrix_set_id: The name of the tile matrix set (e.g. WebMercatorQuad).
     :param tile_matrix: The zoom level or tile matrix it.
@@ -62,35 +62,27 @@ def get_map_tile(
         viewpoint_item = aws.viewpoint_database.get_viewpoint(viewpoint_id)
         validate_viewpoint_status(viewpoint_item.viewpoint_status, ViewpointApiNames.TILE)
 
-        output_type = None
-        if viewpoint_item.range_adjustment is not RangeAdjustmentType.NONE:
-            output_type = gdalconst.GDT_Byte
-
-        tile_factory_pool = get_tile_factory_pool(
-            tile_format, compression, viewpoint_item.local_object_path, output_type, viewpoint_item.range_adjustment
+        image_bytes = tile_provider.get_map_tile(
+            viewpoint_item.local_object_path,
+            tile_matrix_set_id,
+            tile_matrix,
+            tile_row,
+            tile_col,
+            tile_format,
+            compression,
+            viewpoint_item.range_adjustment,
         )
-        with tile_factory_pool.checkout_in_context() as tile_factory:
-            if tile_factory is None:
-                raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail=f"Unable to read tiles from viewpoint {viewpoint_item.viewpoint_id}",
-                )
 
-            # Find the tile in the named tileset
-            tile_set = MapTileSetFactory.get_for_id(tile_matrix_set_id)
-            if not tile_set:
-                raise ValueError(f"Unsupported tile set: {tile_matrix_set_id}")
-            tile_id = MapTileId(tile_matrix=tile_matrix, tile_row=tile_row, tile_col=tile_col)
-            tile = tile_set.get_tile(tile_id)
-
-            # Create an orthophoto for this tile
-            image_bytes = tile_factory.create_orthophoto_tile(geo_bbox=tile.bounds, tile_size=tile.size)
-
+        headers = {"Cache-Control": "private, max-age=604800"}
         if image_bytes is None:
             # OGC Tiles API Section 7.1.7.B indicates that a 204 should be returned for empty tiles
-            return Response(status_code=status.HTTP_204_NO_CONTENT)
+            return Response(status_code=status.HTTP_204_NO_CONTENT, headers=headers)
 
-        return Response(bytes(image_bytes), media_type=get_media_type(tile_format), status_code=status.HTTP_200_OK)
+        return Response(
+            bytes(image_bytes), media_type=get_media_type(tile_format), status_code=status.HTTP_200_OK, headers=headers
+        )
+    except ValueError as err:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Failed to fetch tile. Invalid request. {err}")
     except Exception as err:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to fetch tile for image. {err}"

--- a/test/aws/osml/tile_server/services/test_queue.py
+++ b/test/aws/osml/tile_server/services/test_queue.py
@@ -1,4 +1,4 @@
-#  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2023-2025 Amazon.com, Inc. or its affiliates.
 
 import json
 import unittest

--- a/test/aws/osml/tile_server/services/test_tile_provider.py
+++ b/test/aws/osml/tile_server/services/test_tile_provider.py
@@ -1,0 +1,161 @@
+#  Copyright 2025 Amazon.com, Inc. or its affiliates.
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from aws.osml.gdal import GDALCompressionOptions, GDALImageFormats, RangeAdjustmentType
+from aws.osml.tile_server.services.tile_provider import TileProvider, get_cached_tile_count
+
+
+class TestTileProvider(unittest.TestCase):
+    def setUp(self):
+        """Set up test fixtures before each test method."""
+        self.tile_provider = TileProvider()
+        self.test_image_path = "test/data/test-sample.nitf"
+        self.mock_image_bytes = bytearray(b"mock_image_data")
+
+    def test_get_cached_tile_count_default(self):
+        """Test get_cached_tile_count returns default value when env var is not set"""
+        with patch.dict(os.environ, clear=True):
+            self.assertEqual(get_cached_tile_count(), 400)
+
+    def test_get_cached_tile_count_custom(self):
+        """Test get_cached_tile_count returns custom value from env var"""
+        with patch.dict(os.environ, {"TILE_PROVIDER_CACHED_TILE_COUNT": "800"}):
+            self.assertEqual(get_cached_tile_count(), 800)
+
+    def test_get_cached_tile_count_invalid(self):
+        """Test get_cached_tile_count handles invalid env var value"""
+        with patch.dict(os.environ, {"TILE_PROVIDER_CACHED_TILE_COUNT": "invalid"}):
+            self.assertEqual(get_cached_tile_count(), 400)
+
+    @patch("aws.osml.tile_server.services.tile_provider.get_tile_factory_pool")
+    def test_get_image_tile_success(self, mock_get_pool):
+        """Test successful image tile retrieval"""
+        # Setup mock tile factory
+        mock_tile_factory = MagicMock()
+        mock_tile_factory.create_encoded_tile.return_value = self.mock_image_bytes
+
+        # Setup mock pool context manager
+        mock_pool = MagicMock()
+        mock_pool.checkout_in_context.return_value.__enter__.return_value = mock_tile_factory
+        mock_get_pool.return_value = mock_pool
+
+        result = self.tile_provider.get_image_tile(
+            local_object_path=self.test_image_path,
+            tile_size=512,
+            z=0,
+            y=0,
+            x=0,
+            tile_format=GDALImageFormats.NITF,
+            compression=GDALCompressionOptions.J2K,
+            range_adjustment=RangeAdjustmentType.DRA,
+        )
+
+        self.assertEqual(result, self.mock_image_bytes)
+        mock_tile_factory.create_encoded_tile.assert_called_once()
+
+    @patch("aws.osml.tile_server.services.tile_provider.get_tile_factory_pool")
+    def test_get_image_tile_factory_none(self, mock_get_pool):
+        """Test image tile retrieval when factory is None"""
+        # Setup mock pool to return None
+        mock_pool = MagicMock()
+        mock_pool.checkout_in_context.return_value.__enter__.return_value = None
+        mock_get_pool.return_value = mock_pool
+
+        with self.assertRaises(Exception) as context:
+            self.tile_provider.get_image_tile(
+                local_object_path=self.test_image_path,
+                tile_size=512,
+                z=0,
+                y=0,
+                x=0,
+                tile_format=GDALImageFormats.NITF,
+                compression=GDALCompressionOptions.J2K,
+                range_adjustment=RangeAdjustmentType.NONE,
+            )
+
+        self.assertTrue("Unable to read tiles from viewpoint" in str(context.exception))
+
+    @patch("aws.osml.tile_server.services.tile_provider.get_tile_factory_pool")
+    @patch("aws.osml.tile_server.services.tile_provider.MapTileSetFactory")
+    def test_get_map_tile_success(self, mock_tile_set_factory, mock_get_pool):
+        """Test successful map tile retrieval"""
+        # Setup mock tile factory
+        mock_tile_factory = MagicMock()
+        mock_tile_factory.create_orthophoto_tile.return_value = self.mock_image_bytes
+
+        # Setup mock pool context manager
+        mock_pool = MagicMock()
+        mock_pool.checkout_in_context.return_value.__enter__.return_value = mock_tile_factory
+        mock_get_pool.return_value = mock_pool
+
+        # Setup mock tile set
+        mock_tile_set = MagicMock()
+        mock_tile = MagicMock()
+        mock_tile.bounds = [0, 0, 100, 100]
+        mock_tile.size = 512
+        mock_tile_set.get_tile.return_value = mock_tile
+        mock_tile_set_factory.get_for_id.return_value = mock_tile_set
+
+        result = self.tile_provider.get_map_tile(
+            local_object_path=self.test_image_path,
+            tile_matrix_set_id="WebMercatorQuad",
+            tile_matrix=0,
+            tile_row=0,
+            tile_col=0,
+            tile_format=GDALImageFormats.PNG,
+            compression=GDALCompressionOptions.NONE,
+            range_adjustment=RangeAdjustmentType.DRA,
+        )
+
+        self.assertEqual(result, self.mock_image_bytes)
+        mock_tile_factory.create_orthophoto_tile.assert_called_once()
+
+    @patch("aws.osml.tile_server.services.tile_provider.get_tile_factory_pool")
+    def test_get_map_tile_factory_none(self, mock_get_pool):
+        """Test map tile retrieval when factory is None"""
+        # Setup mock pool to return None
+        mock_pool = MagicMock()
+        mock_pool.checkout_in_context.return_value.__enter__.return_value = None
+        mock_get_pool.return_value = mock_pool
+
+        with self.assertRaises(Exception) as context:
+            self.tile_provider.get_map_tile(
+                local_object_path=self.test_image_path,
+                tile_matrix_set_id="WebMercatorQuad",
+                tile_matrix=0,
+                tile_row=0,
+                tile_col=0,
+                tile_format=GDALImageFormats.PNG,
+                compression=GDALCompressionOptions.NONE,
+                range_adjustment=RangeAdjustmentType.DRA,
+            )
+
+        self.assertTrue("Unable to read tiles from viewpoint" in str(context.exception))
+
+    @patch("aws.osml.tile_server.services.tile_provider.MapTileSetFactory")
+    def test_get_map_tile_invalid_tile_set(self, mock_tile_set_factory):
+        """Test map tile retrieval with invalid tile set ID"""
+        # Setup mock tile set factory to return None
+        mock_tile_set_factory.get_for_id.return_value = None
+
+        with self.assertRaises(ValueError) as context:
+            self.tile_provider.get_map_tile(
+                local_object_path=self.test_image_path,
+                tile_matrix_set_id="InvalidTileSet",
+                tile_matrix=0,
+                tile_row=0,
+                tile_col=0,
+                tile_format=GDALImageFormats.PNG,
+                compression=GDALCompressionOptions.NONE,
+                range_adjustment=RangeAdjustmentType.DRA,
+            )
+
+        print(f"EXCEPTION: {context.exception}")
+        self.assertTrue("Unsupported tile set" in str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR updates the tile server to cache previously created map and image tiles. It also adds a [Cache-Control header](https://httpwg.org/specs/rfc9111.html#field.cache-control) that instructs clients to keep the tiles for up to 7 days. Combined these two features eliminate many duplicate tile generation requests improving the overall responsiveness of visualization tools using the tile server.

The implementation introduces a new `TileProvider` service that is injected into the handlers for various tile / map routes. The `get_image_tile` and `get_map_tile` methods are wrapped in a LRU cache with a max size that can be configured by setting the `TILE_PROVIDER_CACHED_TILE_COUNT` environment variable. This configuration setting defaults to 400 tiles if not found in the environment.

Unit tests were updated to validate the new TileProvider and end-to-end functionality was checked through an integration with STACBrowser.

This PR also contains a second commit for a small build issue found during testing. The autopep8 checks run in our pre-commit setup were failing because they could not find the lib2to3 module. That module was officially deprecated / removed in Python 3.11 but older versions of the autopep8 tool still depended on it. Updating to the latest version resolved the issue.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
